### PR TITLE
chore(deps): update @pgpmjs/* to published versions (SqlProgram + graph-based exclusion)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lerna": "^8.2.3",
     "prettier": "^3.8.1",
     "rimraf": "^6.1.3",
-    "supabase-test": "^3.8.6",
+    "supabase-test": "^3.8.7",
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       supabase-test:
-        specifier: ^3.8.6
-        version: 3.8.6
+        specifier: ^3.8.7
+        version: 3.8.7
       ts-jest:
         specifier: ^29.4.11
         version: 29.4.12(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -73,26 +73,26 @@ importers:
         specifier: ^0.12.4
         version: 0.12.4
       '@pgpmjs/core':
-        specifier: 7.17.2
-        version: 7.17.2
+        specifier: 7.18.0
+        version: 7.18.0
       '@pgpmjs/env':
         specifier: 2.39.2
         version: 2.39.2
       '@pgpmjs/slice':
-        specifier: 0.11.2
-        version: 0.11.2
+        specifier: 0.12.0
+        version: 0.12.0
       '@pgpmjs/transform':
-        specifier: 0.12.2
-        version: 0.12.2
+        specifier: 0.13.0
+        version: 0.13.0
       '@pgpmjs/types':
         specifier: 2.48.1
         version: 2.48.1
       pgsql-test:
-        specifier: ^5.8.6
-        version: 5.8.6
+        specifier: ^5.8.7
+        version: 5.8.7
       supabase-test:
-        specifier: ^3.8.6
-        version: 3.8.6
+        specifier: ^3.8.7
+        version: 3.8.7
 
 packages:
 
@@ -686,8 +686,8 @@ packages:
   '@pgpmjs/bundle@0.12.4':
     resolution: {integrity: sha512-LFpKf5VCKUF4HyuGbqCGcZ41gSITpnoz5r0WY7Yx8FNUddYdkLymqo3DBVHFkwOHHGcal3UjV3Baf2WvkHPHAg==}
 
-  '@pgpmjs/core@7.17.2':
-    resolution: {integrity: sha512-oED5EYBlO27V26C2iTTJaJf9BM3A6IyBO2C1jDUDmhPb274hrOW8Ysctdpv/RKeAxhUeJzK4uq2FzehYtpwyMA==}
+  '@pgpmjs/core@7.18.0':
+    resolution: {integrity: sha512-tYZoAln9kTqu9DU2sd0z4sblDpqBHB2RHqneoZIG7RNAftAdUJvvzbZljej6dSmXDm1w9usOS5vhOw+eqW3+Zw==}
 
   '@pgpmjs/env@2.39.2':
     resolution: {integrity: sha512-ZX+wQUG8ZbzzXcbixi60gtslaOe6Cfu7FjjKMIYn4S1DYi5XcZGA4TKEtgskbfIsUF4iXcEg4eXIvDeBe+8hRA==}
@@ -698,11 +698,11 @@ packages:
   '@pgpmjs/server-utils@3.23.4':
     resolution: {integrity: sha512-+LYocviQk5aQW9XlUM8+NsGyFIEUZ9+raqxpl6Gi7dysRVQCsTG0Kx/9fK7G+WxGIC6jBtjjHGyErb72/ux/sg==}
 
-  '@pgpmjs/slice@0.11.2':
-    resolution: {integrity: sha512-bl8VPvg6I2RHd7IhqcAk5vLNsmMboO4TnXnLYkjmAAVM2dVoH76iGlRU2Rp9wvq+PchDBKjvgXbn7ywED6svhQ==}
+  '@pgpmjs/slice@0.12.0':
+    resolution: {integrity: sha512-t638HrMbCefdbCq0/AUa79yYfIuXqNmfi2Fq1qoipOXFq8XGpaxETT+mFt5j5lf3NdSYFz077bFEqYW0MHMb1w==}
 
-  '@pgpmjs/transform@0.12.2':
-    resolution: {integrity: sha512-e8hdUowLSC66dSgjiYxR41KXfDhKIf/AiuWBJ+zCBTF11mJydhYMGDKuYTaSTGtdWfYza2IPto3V+KPNt84ILg==}
+  '@pgpmjs/transform@0.13.0':
+    resolution: {integrity: sha512-Hlt0rlD7yKARweodmYe3PcfVKwOKVp6ChasHpVZzzZKwEEP5Oj6K8eeOuC0Q9O4LR59G49UXI04PElwCERl0Mw==}
 
   '@pgpmjs/traverse@0.9.5':
     resolution: {integrity: sha512-wmIcHDr+PhdpmSXN/c9wpeDBpUylnjBiTXucoVdxJzDtNkec3c56um873WDX0R2+zQOGGqtBj8aRRMHnGnvnlQ==}
@@ -713,11 +713,11 @@ packages:
   '@pgsql/quotes@18.1.0':
     resolution: {integrity: sha512-wZcMP1QHiQbWWKOw4nfvZ74xUSz/9jqeSUXVnoR1saI5M0D+iYbiuOlfNDyYmziLwgEkCuSJLZK1dZ+eQCwgAA==}
 
-  '@pgsql/transform@18.7.0':
-    resolution: {integrity: sha512-KjG/vk2X+ST/OgKEnR/Z/ldbE7S1XggNZmYyfFoRVRXTlwtPjoVOBxceF/fvt8sA7w+ydD9KppervlS91fEyFw==}
+  '@pgsql/transform@18.8.0':
+    resolution: {integrity: sha512-orYvqoD34XPwpp4KgJNiXZFOmze2dSZOd3gwHHyy2fICf+5XXN5IBX14tJxiwon2k8NpPfpjQ5xSQjDhK5uRzQ==}
 
-  '@pgsql/traverse@18.3.0':
-    resolution: {integrity: sha512-5DOD9OExBT8wvejdQavnpWlI9625w2j3Mi+ecvCUxaXz/R+Lesj3lsp8Bp7gmUFEOJ7hbhDr0zCzfJkjPHjsJw==}
+  '@pgsql/traverse@18.4.0':
+    resolution: {integrity: sha512-7D6mjHwW6gpTp0/tCwrthzctDtGgo63R+Y0fBIRNYwUMTOj45Jhnlsj67mlq9yv+BgDZguWawo59EGdIF3vrgg==}
 
   '@pgsql/types@18.0.0':
     resolution: {integrity: sha512-jtAY4JU7jdVYZ/Vv3zlZqVP+FRWZokyCLKPPCnAApiaJAElpyyiMC3HRiquBu29kSrVs+rkqZD50SUIb/zyEGw==}
@@ -3067,8 +3067,8 @@ packages:
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
-  pgsql-client@4.8.6:
-    resolution: {integrity: sha512-diEApLekSpn1epvHrrHEaTivuxsh2HYzlnlbQ2o/9dsyDLe5GPTgT0yflR8zid8uC1dFXFMUTzGyy+nIKMbahw==}
+  pgsql-client@4.8.7:
+    resolution: {integrity: sha512-D9Ct8h+oxF/9tHx+A3v3ixU81kwVco0pLXLcVixcWE1R41IKc2twZ3GUuzAQubFdZh/DzNcXOfy8/Uk5IBkwYA==}
 
   pgsql-deparser@18.1.1:
     resolution: {integrity: sha512-G+5yj8rGlkW5YUJTKubV3J5YnAvbm8YpzphT1bYkRjAI5MKTVRXwGZJ0gqluqjhLNqDw6d20IFE4J5Z7yEmwWg==}
@@ -3076,11 +3076,11 @@ packages:
   pgsql-parser@18.1.1:
     resolution: {integrity: sha512-wMOCDIuj7TOGy1gxYn2B0/y2row8sOIbPJ4IMkLD0fpgwgGZN26TYK+05AG27WExgzp9JGr9EbTaCF8T1sVzrQ==}
 
-  pgsql-seed@3.8.6:
-    resolution: {integrity: sha512-51JZJNaa3+Emu8Wslm6PtHVps3DDW048ODMGZWPx7kohyXd5AW93pPpL14PpcSjJIphM4gDtQRhPwXWmMYBsNg==}
+  pgsql-seed@3.8.7:
+    resolution: {integrity: sha512-RTfAQ6Z4SOK8pZuKcjtLGeu1M0RQcc1dRuVnV1ZQMeMShH7EFysJNLvGFZ62gKVeVaEYa/AvSmcgbuRelDBAZg==}
 
-  pgsql-test@5.8.6:
-    resolution: {integrity: sha512-YK9yxnA0v1R7WanNYdcHsTn4SkWbeBR7lINMQfxai7+8yUQv6G9CFOzKQKe9MS5XokunGm0vGtnnenl/FLRCmA==}
+  pgsql-test@5.8.7:
+    resolution: {integrity: sha512-oEAdHkEY30cK3WrBEF5+O5j16KDa7rJ/p1ctgX8ET2k4E1NRxGgpmP6RVc9dCBHK6cW3QrXij38mLngT8inNWQ==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3120,8 +3120,8 @@ packages:
   plpgsql-deparser@18.1.2:
     resolution: {integrity: sha512-r9uqdSAU+9hve08jFpCoYHe1C7IbuIANhOAJFMNZVcPzoxAhvTRNlngLnzlrVQUXADj7Jcqcn+848SWdOLBktA==}
 
-  plpgsql-parser@18.2.1:
-    resolution: {integrity: sha512-ydrn6KcCqVDN9XM4PNz7qAiFl5Nk/tf/hXa2l3KDZAuCPAu1lYp3iIqyFzr0jCebFJ4nTxR96eQpFUsZUgzLJw==}
+  plpgsql-parser@18.2.2:
+    resolution: {integrity: sha512-XzuvvbZredJeLp3ByOOcNbHthB7kmyi2a/D9vWgyLy7UZBQGP869KziBCeB1TruPRm2JgkC50B2msi3lXZ+DNA==}
 
   postcss-selector-parser@6.1.4:
     resolution: {integrity: sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==}
@@ -3514,8 +3514,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  supabase-test@3.8.6:
-    resolution: {integrity: sha512-1x1k+3Mh3azdNRqyTsTjaSMn/HHgh6e1Hl/sRwtjb4h37LEzCSe1NSxTsRkXHwDIJleHx0pDRB8Y/Cl91iw2fA==}
+  supabase-test@3.8.7:
+    resolution: {integrity: sha512-O2xzlMQa09SXvPZflGJgcioXP7mGmQ+pyN+G8nJcbzMNxTai5loE+oFFBkCOf7leyq4FHm7rzm9IzZAkg321NQ==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4762,15 +4762,15 @@ snapshots:
       '@pgpmjs/ast': 0.9.5
       '@pgpmjs/traverse': 0.9.5
 
-  '@pgpmjs/core@7.17.2':
+  '@pgpmjs/core@7.18.0':
     dependencies:
       '@pgpmjs/ast': 0.9.5
       '@pgpmjs/bundle': 0.12.4
       '@pgpmjs/env': 2.39.2
       '@pgpmjs/logger': 2.22.1
       '@pgpmjs/server-utils': 3.23.4
-      '@pgpmjs/slice': 0.11.2
-      '@pgpmjs/transform': 0.12.2
+      '@pgpmjs/slice': 0.12.0
+      '@pgpmjs/transform': 0.13.0
       '@pgpmjs/types': 2.48.1
       csv-to-pg: 4.8.1
       genomic: 5.6.2
@@ -4806,19 +4806,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@pgpmjs/slice@0.11.2':
+  '@pgpmjs/slice@0.12.0':
     dependencies:
       '@pgpmjs/ast': 0.9.5
-      '@pgpmjs/transform': 0.12.2
+      '@pgpmjs/transform': 0.13.0
       minimatch: 10.2.6
-      plpgsql-parser: 18.2.1
+      plpgsql-parser: 18.2.2
     transitivePeerDependencies:
       - supports-color
 
-  '@pgpmjs/transform@0.12.2':
+  '@pgpmjs/transform@0.13.0':
     dependencies:
-      '@pgsql/transform': 18.7.0
-      plpgsql-parser: 18.2.1
+      '@pgsql/transform': 18.8.0
+      plpgsql-parser: 18.2.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4833,15 +4833,15 @@ snapshots:
 
   '@pgsql/quotes@18.1.0': {}
 
-  '@pgsql/transform@18.7.0':
+  '@pgsql/transform@18.8.0':
     dependencies:
       '@pgsql/quotes': 18.1.0
-      '@pgsql/traverse': 18.3.0
-      plpgsql-parser: 18.2.1
+      '@pgsql/traverse': 18.4.0
+      plpgsql-parser: 18.2.2
     transitivePeerDependencies:
       - supports-color
 
-  '@pgsql/traverse@18.3.0':
+  '@pgsql/traverse@18.4.0':
     dependencies:
       '@pgsql/types': 18.0.0
       pg-proto-parser: 1.31.0
@@ -7566,9 +7566,9 @@ snapshots:
     dependencies:
       split2: 4.2.0
 
-  pgsql-client@4.8.6:
+  pgsql-client@4.8.7:
     dependencies:
-      '@pgpmjs/core': 7.17.2
+      '@pgpmjs/core': 7.18.0
       '@pgpmjs/logger': 2.22.1
       '@pgpmjs/types': 2.48.1
       pg: 8.22.0
@@ -7588,9 +7588,9 @@ snapshots:
       libpg-query: 18.1.2
       pgsql-deparser: 18.1.1
 
-  pgsql-seed@3.8.6:
+  pgsql-seed@3.8.7:
     dependencies:
-      '@pgpmjs/core': 7.17.2
+      '@pgpmjs/core': 7.18.0
       '@pgpmjs/env': 2.39.2
       pg: 8.22.0
       pg-env: 1.26.1
@@ -7599,7 +7599,7 @@ snapshots:
       - pg-native
       - supports-color
 
-  pgsql-test@5.8.6:
+  pgsql-test@5.8.7:
     dependencies:
       '@pgpmjs/env': 2.39.2
       '@pgpmjs/logger': 2.22.1
@@ -7608,8 +7608,8 @@ snapshots:
       pg: 8.22.0
       pg-cache: 3.23.4
       pg-env: 1.26.1
-      pgsql-client: 4.8.6
-      pgsql-seed: 3.8.6
+      pgsql-client: 4.8.7
+      pgsql-seed: 3.8.7
     transitivePeerDependencies:
       - pg-native
       - supports-color
@@ -7639,9 +7639,9 @@ snapshots:
       '@pgsql/types': 18.0.0
       pgsql-deparser: 18.1.1
 
-  plpgsql-parser@18.2.1:
+  plpgsql-parser@18.2.2:
     dependencies:
-      '@pgsql/traverse': 18.3.0
+      '@pgsql/traverse': 18.4.0
       '@pgsql/types': 18.0.0
       libpg-query: 18.1.2
       pgsql-deparser: 18.1.1
@@ -8049,12 +8049,12 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  supabase-test@3.8.6:
+  supabase-test@3.8.7:
     dependencies:
       '@pgpmjs/types': 2.48.1
       deepmerge: 4.3.1
       pg-env: 1.26.1
-      pgsql-test: 5.8.6
+      pgsql-test: 5.8.7
     transitivePeerDependencies:
       - pg-native
       - supports-color

--- a/portability/packages/portability-tests/package.json
+++ b/portability/packages/portability-tests/package.json
@@ -10,13 +10,13 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@pgpmjs/core": "7.17.2",
+    "@pgpmjs/core": "7.18.0",
     "@pgpmjs/env": "2.39.2",
-    "@pgpmjs/slice": "0.11.2",
-    "@pgpmjs/transform": "0.12.2",
+    "@pgpmjs/slice": "0.12.0",
+    "@pgpmjs/transform": "0.13.0",
     "@pgpmjs/types": "2.48.1",
-    "pgsql-test": "^5.8.6",
-    "supabase-test": "^3.8.6",
+    "pgsql-test": "^5.8.7",
+    "supabase-test": "^3.8.7",
     "@pgpmjs/bundle": "^0.12.4"
   },
   "keywords": []

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,414 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "supabase-test-suite"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+# Controls whether new tables, views, sequences and functions created in the `public` schema by
+# `postgres` are reachable through the Data API roles (`anon`, `authenticated`, `service_role`)
+# without explicit GRANTs. When unset, new entities are NOT auto-exposed, matching the new cloud
+# default. Set to `true` to keep the legacy behaviour of auto-exposing new entities; this is
+# deprecated and the field is removed on 2026-10-30 once the always-revoked behaviour is permanent.
+# auto_expose_new_tables = true
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files, directories, or glob patterns that describe your database.
+# Supports paths relative to supabase directory: "./schemas/*.sql", "./database".
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[local_smtp]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+[storage.vector]
+enabled = true
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ `{{ .Code }}` }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ `{{ .Code }}` }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# pg-delta is the schema diff engine for db diff / db pull / db remote commit.
+# Set enabled = false to fall back to the legacy migra engine.
+[experimental.pgdelta]
+enabled = true
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"


### PR DESCRIPTION
## Summary

`makage update-deps --from ./constructive` bump to the freshly published pgpm packages that carry the SqlProgram statement layer (constructive #1535) and graph-based subsystem exclusion (constructive #1538):

```
@pgpmjs/core       7.17.2 → 7.18.0
@pgpmjs/slice      0.11.2 → 0.12.0
@pgpmjs/transform  0.12.2 → 0.13.0
pgsql-test         ^5.8.6 → ^5.8.7
supabase-test      ^3.8.6 → ^3.8.7
```

No source changes — the portability transforms are behavior-compatible (exclusion/route/rebind APIs unchanged; the new versions only converge the internals). Plain-PG portability suite (`deploy-ported`, `transpile`, `contract`) verified green locally; the vendor-image job runs `deploy-vendor` in CI.

Link to Devin session: https://app.devin.ai/sessions/025fb88043964fdbb335ac5e39df2478
Requested by: @pyramation