### PR TITLE
feat(portability): committed materialized (ejected) vendor modules, both directions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lerna": "^8.2.3",
     "prettier": "^3.8.1",
     "rimraf": "^6.1.3",
-    "supabase-test": "^3.8.7",
+    "supabase-test": "^3.9.0",
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       supabase-test:
-        specifier: ^3.8.7
-        version: 3.8.7
+        specifier: ^3.9.0
+        version: 3.9.0
       ts-jest:
         specifier: ^29.4.11
         version: 29.4.12(@babel/core@7.29.7)(@jest/transform@30.4.1)(@jest/types@30.4.1)(babel-jest@30.4.1(@babel/core@7.29.7))(jest-util@30.4.1)(jest@30.4.2(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.9.3)))(typescript@5.9.3)
@@ -70,34 +70,37 @@ importers:
   portability/packages/portability-tests:
     dependencies:
       '@pgpmjs/bundle':
-        specifier: ^0.12.4
-        version: 0.12.4
+        specifier: ^0.13.0
+        version: 0.13.0
       '@pgpmjs/core':
-        specifier: 7.18.0
-        version: 7.18.0
+        specifier: 7.20.0
+        version: 7.20.0
       '@pgpmjs/env':
-        specifier: 2.39.2
-        version: 2.39.2
+        specifier: 2.40.0
+        version: 2.40.0
+      '@pgpmjs/portability':
+        specifier: 0.3.0
+        version: 0.3.0
       '@pgpmjs/slice':
-        specifier: 0.12.0
-        version: 0.12.0
-      '@pgpmjs/transform':
         specifier: 0.13.0
         version: 0.13.0
+      '@pgpmjs/transform':
+        specifier: 0.14.0
+        version: 0.14.0
       '@pgpmjs/types':
-        specifier: 2.48.1
-        version: 2.48.1
+        specifier: 2.49.0
+        version: 2.49.0
       pgsql-test:
-        specifier: ^5.8.7
-        version: 5.8.7
+        specifier: ^5.9.0
+        version: 5.9.0
       supabase-test:
-        specifier: ^3.8.7
-        version: 3.8.7
+        specifier: ^3.9.0
+        version: 3.9.0
 
 packages:
 
-  12factor-env@1.25.1:
-    resolution: {integrity: sha512-mhqpwoKDJnxGHiZY67tw+B9jK4PQfYSz4CswVK9g6hehTnTAMAffs1qfNoYymOb20v80c697dANmd4wjt5ENCw==}
+  12factor-env@1.26.0:
+    resolution: {integrity: sha512-KhvmJiJtPJhsdYof5OSkC+V+QVRMdEZiwk5ElqnjTFK5sF2ljDSRmSDpIYvAuxtDH1+Dsf2C4KiwIlCQcvTH3g==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -272,8 +275,8 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@constructive-io/errors@0.7.2':
-    resolution: {integrity: sha512-8Pnxq0uGwJpnwLgLYOlMJNxz3m8Zp/9Dc7kc1LI2S+77B6jhBaViGtpcm8E4Wb1GB8MDfvJhvnDMeX/i0tZjyw==}
+  '@constructive-io/errors@0.8.0':
+    resolution: {integrity: sha512-HoBaM+41XxV2OzYeVrc7Cxs0ndSCI9mikWukYlCCOuIrQ7aeWyZ8Imy3CGcw+QEwmmhquDVWZGUYR4z5Zkm7eQ==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -680,35 +683,38 @@ packages:
   '@octokit/types@13.10.0':
     resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
 
-  '@pgpmjs/ast@0.9.5':
-    resolution: {integrity: sha512-S6k0mQMLHd8Amr9s7bGjJcMNlXxY7cqDaa63DZf/mjYgN4s5/ao2Uq0o7My22Hd7e4RBc0/KFldAskNoQLlE5A==}
+  '@pgpmjs/ast@0.10.0':
+    resolution: {integrity: sha512-NphU7Jcpjymo/5UPlcXephoF/g9I0U1zQkFJI1VvgnsuBtceNt923WCqi5uIxhVQglGx3d72ytx58j7tQaru/A==}
 
-  '@pgpmjs/bundle@0.12.4':
-    resolution: {integrity: sha512-LFpKf5VCKUF4HyuGbqCGcZ41gSITpnoz5r0WY7Yx8FNUddYdkLymqo3DBVHFkwOHHGcal3UjV3Baf2WvkHPHAg==}
+  '@pgpmjs/bundle@0.13.0':
+    resolution: {integrity: sha512-Do4uJh3DTox/O9JgqUCksd7H+I7QDp/xLTEkTbf95FXNafxZtQd6900LAaa8tNdrItQ5BeXkACMcAB2QztZ83Q==}
 
-  '@pgpmjs/core@7.18.0':
-    resolution: {integrity: sha512-tYZoAln9kTqu9DU2sd0z4sblDpqBHB2RHqneoZIG7RNAftAdUJvvzbZljej6dSmXDm1w9usOS5vhOw+eqW3+Zw==}
+  '@pgpmjs/core@7.20.0':
+    resolution: {integrity: sha512-f4h7YEDW0vtYqNd6Qj7Y7tGtQD16T52Cgey9cPdYIuuSJEKYONGxCI0OzlVLMFP3jIUHldyxoD0WZvEfFyWhdA==}
 
-  '@pgpmjs/env@2.39.2':
-    resolution: {integrity: sha512-ZX+wQUG8ZbzzXcbixi60gtslaOe6Cfu7FjjKMIYn4S1DYi5XcZGA4TKEtgskbfIsUF4iXcEg4eXIvDeBe+8hRA==}
+  '@pgpmjs/env@2.40.0':
+    resolution: {integrity: sha512-RcBicw6I944xjxZPxFQywrTKm08hGFRS7vuJoYs2yvNUNuuAqSZFpjrPQHLQDomLY7ZdkLPiJsp4vN8YuoL0iw==}
 
-  '@pgpmjs/logger@2.22.1':
-    resolution: {integrity: sha512-xRqaoBf9Sdw2v+PVZfdHsO8jg9ZWMntRRIk21lSFtPV40BYxcsTLDCyGycLTZr3Ao8FVRIOOsPiemUy4CuI7aQ==}
+  '@pgpmjs/logger@2.23.0':
+    resolution: {integrity: sha512-e7MlyjsIgVhp7xFi7ZtcS9e5HNIHYJWQhstWyWjMrI+b4o/iX3LzQ/mYOa4pCei1BIsxcMzWyoXfNbBB3IMo0g==}
 
-  '@pgpmjs/server-utils@3.23.4':
-    resolution: {integrity: sha512-+LYocviQk5aQW9XlUM8+NsGyFIEUZ9+raqxpl6Gi7dysRVQCsTG0Kx/9fK7G+WxGIC6jBtjjHGyErb72/ux/sg==}
+  '@pgpmjs/portability@0.3.0':
+    resolution: {integrity: sha512-E/4DF+QhNMScBkQ1/NKokqWg3aB97iUBJzMOlxHKGuBDA8Jzi3R/RQAfnnXpgfS478HsoUzrd+G9q2OSm059/w==}
 
-  '@pgpmjs/slice@0.12.0':
-    resolution: {integrity: sha512-t638HrMbCefdbCq0/AUa79yYfIuXqNmfi2Fq1qoipOXFq8XGpaxETT+mFt5j5lf3NdSYFz077bFEqYW0MHMb1w==}
+  '@pgpmjs/server-utils@3.24.0':
+    resolution: {integrity: sha512-GccG46t5RZJdjIblibl63mP2AUPmPA0ckwAotg57iVIcsghOzKvc3wnkvgeZxBaOJz5CSPcyidn/zwWRu/6zyg==}
 
-  '@pgpmjs/transform@0.13.0':
-    resolution: {integrity: sha512-Hlt0rlD7yKARweodmYe3PcfVKwOKVp6ChasHpVZzzZKwEEP5Oj6K8eeOuC0Q9O4LR59G49UXI04PElwCERl0Mw==}
+  '@pgpmjs/slice@0.13.0':
+    resolution: {integrity: sha512-p9UcV9jeMETqPx6Fh7mSnGuTq47OHKXSc4FvDN+jW0Ti4E2wIPjSOYRGqHF4MuxI0bzjqg6hzBzNDOCVPzmCxg==}
 
-  '@pgpmjs/traverse@0.9.5':
-    resolution: {integrity: sha512-wmIcHDr+PhdpmSXN/c9wpeDBpUylnjBiTXucoVdxJzDtNkec3c56um873WDX0R2+zQOGGqtBj8aRRMHnGnvnlQ==}
+  '@pgpmjs/transform@0.14.0':
+    resolution: {integrity: sha512-YJnIhZyRhVfnEEOw/+8tPBfepglXreZXPEPasgEBcE+3fezIwF5njHfnBePA/f5MLhOSDwoavMe+jHe2iPaOUw==}
 
-  '@pgpmjs/types@2.48.1':
-    resolution: {integrity: sha512-k0Rqm/Cuqh1Jh4IQICyFbrAhC9X0ZTIlLXOpF18Pp86BwrUbd9uFtzawE6du7hPFcvL4aASgUSvEOJg5GsLfoQ==}
+  '@pgpmjs/traverse@0.10.0':
+    resolution: {integrity: sha512-nkOSYh2gZhLmiV8Oym2Y32l8I1Tt1WpRZWzmM3SRdURq7S4OOtamf54vJVAwkPIaZe0/s+WdfwzZa3qFj+sHXQ==}
+
+  '@pgpmjs/types@2.49.0':
+    resolution: {integrity: sha512-7ZMyZ9fdAvnmhvC9/47SjHNeuVRImuLlEFELoAEUsLk10N/G/Y84y9N1EWSCJL4NY3TIX1/wJGcE+vhySWlPrg==}
 
   '@pgsql/quotes@18.1.0':
     resolution: {integrity: sha512-wZcMP1QHiQbWWKOw4nfvZ74xUSz/9jqeSUXVnoR1saI5M0D+iYbiuOlfNDyYmziLwgEkCuSJLZK1dZ+eQCwgAA==}
@@ -1510,8 +1516,8 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  csv-to-pg@4.8.1:
-    resolution: {integrity: sha512-klNg6oUNp4vNUfFRur5Pkvf5kctxKslPBryws55L01ks0avZCyOs9/4wsb+QHk5+2fzirEkc0pLPYIxtNUYErw==}
+  csv-to-pg@4.9.0:
+    resolution: {integrity: sha512-yHengcvXl81FGWzsNjNGOIfGCxUYYBVDyWYMTm5UX8vY7FrUlRsQXRBrd+DZX7VrTsHAZgFfeuXwb8/dgSWCRQ==}
     hasBin: true
 
   dargs@7.0.0:
@@ -3018,8 +3024,8 @@ packages:
     resolution: {integrity: sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==}
     engines: {node: '>=4'}
 
-  pg-cache@3.23.4:
-    resolution: {integrity: sha512-mVvT7Pl9qB6cNpWMZ0kvWPrNGwYsqoVozcId9n3WxazmS4/kiDkCg7uq6t218ySgyofV4ClvcgVYhxiadzRSow==}
+  pg-cache@3.24.0:
+    resolution: {integrity: sha512-FjY9SsIFhsnuSNNtV+j2vVLu3v9gNKBHfiHtH+7rx59wE4mdT5rKLTw1nw1wKEFowAbYCobgcofb5XiNKVacgg==}
 
   pg-cloudflare@1.4.0:
     resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
@@ -3030,8 +3036,8 @@ packages:
   pg-copy-streams@7.0.0:
     resolution: {integrity: sha512-zBvnY6wtaBRE2ae2xXWOOGMaNVPkXh1vhypAkNSKgMdciJeTyIQAHZaEeRAxUjs/p1El5jgzYmwG5u871Zj3dQ==}
 
-  pg-env@1.26.1:
-    resolution: {integrity: sha512-X9rMb68Q7xtd/ln/yogFQ6+qkeX6GOWC5r5GJdnBC6UW6ENhwblF2JLQEKDGpMYBYP9D+Qwj8QuPWonoRJ4p3w==}
+  pg-env@1.27.0:
+    resolution: {integrity: sha512-fJbFOwSfLn8wPbngvPhzdh58eeGHDs8ca1tuG5SJoOz1x16fWS+Y92dBKWqqebBawuuGJmKzt2qVEpV8WRK9RA==}
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -3048,8 +3054,8 @@ packages:
   pg-protocol@1.15.0:
     resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
 
-  pg-seed@0.25.1:
-    resolution: {integrity: sha512-b20QZm4fziZrS21nXTTe2P4L1l/X0ogOe9MnUljNMRMEgoKbozC2+kwPebLVOZeD9u/CGcXcS1KRSn1UP6BmTw==}
+  pg-seed@0.26.0:
+    resolution: {integrity: sha512-JJU1DBIXGNJWqEsubSStre/YEXFNmxHeOtHGiwtJpuuOM3c9oeYFRr1le3bJ+cO5oXh+YVCH+wMYABqWLrNP2g==}
 
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
@@ -3067,8 +3073,8 @@ packages:
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
-  pgsql-client@4.8.7:
-    resolution: {integrity: sha512-D9Ct8h+oxF/9tHx+A3v3ixU81kwVco0pLXLcVixcWE1R41IKc2twZ3GUuzAQubFdZh/DzNcXOfy8/Uk5IBkwYA==}
+  pgsql-client@4.9.0:
+    resolution: {integrity: sha512-sPZVkMsjD3JtXcU3CI3WXp5yz3GNfFQehoi7AFr4i84r+yvJ9aZ9BaRaloHgZkngP2u1AWe4uGP2iXej7d8vzQ==}
 
   pgsql-deparser@18.1.1:
     resolution: {integrity: sha512-G+5yj8rGlkW5YUJTKubV3J5YnAvbm8YpzphT1bYkRjAI5MKTVRXwGZJ0gqluqjhLNqDw6d20IFE4J5Z7yEmwWg==}
@@ -3076,11 +3082,11 @@ packages:
   pgsql-parser@18.1.1:
     resolution: {integrity: sha512-wMOCDIuj7TOGy1gxYn2B0/y2row8sOIbPJ4IMkLD0fpgwgGZN26TYK+05AG27WExgzp9JGr9EbTaCF8T1sVzrQ==}
 
-  pgsql-seed@3.8.7:
-    resolution: {integrity: sha512-RTfAQ6Z4SOK8pZuKcjtLGeu1M0RQcc1dRuVnV1ZQMeMShH7EFysJNLvGFZ62gKVeVaEYa/AvSmcgbuRelDBAZg==}
+  pgsql-seed@3.9.0:
+    resolution: {integrity: sha512-TfvKRegnJhw9iiceDyK6FNmZkIiLuBruSAgXwpeuWCHxnbQNIqPgkwJ6820WvXU3dGvkCzRT+vqz4PecYyBD+Q==}
 
-  pgsql-test@5.8.7:
-    resolution: {integrity: sha512-oEAdHkEY30cK3WrBEF5+O5j16KDa7rJ/p1ctgX8ET2k4E1NRxGgpmP6RVc9dCBHK6cW3QrXij38mLngT8inNWQ==}
+  pgsql-test@5.9.0:
+    resolution: {integrity: sha512-itqdtsU55nWguxkZK1IgW+VI2NK4Y2u64DSbxW0S10PqPhkQpyyaTlhidXZyFaRtomt/wKdx6d7lhWCLPtXj1Q==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3514,8 +3520,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  supabase-test@3.8.7:
-    resolution: {integrity: sha512-O2xzlMQa09SXvPZflGJgcioXP7mGmQ+pyN+G8nJcbzMNxTai5loE+oFFBkCOf7leyq4FHm7rzm9IzZAkg321NQ==}
+  supabase-test@3.9.0:
+    resolution: {integrity: sha512-XaEnnMf2eB+40c215oEevqrERFreaiGgX1OpP2nI1D/nJQ8n1jXSPID6sM3QqZCWG/TcPD08N7QYIRNscw4dpA==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -3878,7 +3884,7 @@ packages:
 
 snapshots:
 
-  12factor-env@1.25.1:
+  12factor-env@1.26.0:
     dependencies:
       envalid: 8.2.0
 
@@ -4088,7 +4094,7 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@constructive-io/errors@0.7.2': {}
+  '@constructive-io/errors@0.8.0': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -4752,33 +4758,33 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 24.2.0
 
-  '@pgpmjs/ast@0.9.5':
+  '@pgpmjs/ast@0.10.0':
     dependencies:
-      '@pgpmjs/env': 2.39.2
-      '@pgpmjs/types': 2.48.1
+      '@pgpmjs/env': 2.40.0
+      '@pgpmjs/types': 2.49.0
 
-  '@pgpmjs/bundle@0.12.4':
+  '@pgpmjs/bundle@0.13.0':
     dependencies:
-      '@pgpmjs/ast': 0.9.5
-      '@pgpmjs/traverse': 0.9.5
+      '@pgpmjs/ast': 0.10.0
+      '@pgpmjs/traverse': 0.10.0
 
-  '@pgpmjs/core@7.18.0':
+  '@pgpmjs/core@7.20.0':
     dependencies:
-      '@pgpmjs/ast': 0.9.5
-      '@pgpmjs/bundle': 0.12.4
-      '@pgpmjs/env': 2.39.2
-      '@pgpmjs/logger': 2.22.1
-      '@pgpmjs/server-utils': 3.23.4
-      '@pgpmjs/slice': 0.12.0
-      '@pgpmjs/transform': 0.13.0
-      '@pgpmjs/types': 2.48.1
-      csv-to-pg: 4.8.1
+      '@pgpmjs/ast': 0.10.0
+      '@pgpmjs/bundle': 0.13.0
+      '@pgpmjs/env': 2.40.0
+      '@pgpmjs/logger': 2.23.0
+      '@pgpmjs/server-utils': 3.24.0
+      '@pgpmjs/slice': 0.13.0
+      '@pgpmjs/transform': 0.14.0
+      '@pgpmjs/types': 2.49.0
+      csv-to-pg: 4.9.0
       genomic: 5.6.2
       glob: 13.0.6
       parse-package-name: 1.0.0
       pg: 8.22.0
-      pg-cache: 3.23.4
-      pg-env: 1.26.1
+      pg-cache: 3.24.0
+      pg-env: 1.27.0
       pgsql-deparser: 18.1.1
       pgsql-parser: 18.1.1
       yanse: 0.2.1
@@ -4786,50 +4792,60 @@ snapshots:
       - pg-native
       - supports-color
 
-  '@pgpmjs/env@2.39.2':
+  '@pgpmjs/env@2.40.0':
     dependencies:
-      12factor-env: 1.25.1
-      '@pgpmjs/types': 2.48.1
+      12factor-env: 1.26.0
+      '@pgpmjs/types': 2.49.0
       deepmerge: 4.3.1
 
-  '@pgpmjs/logger@2.22.1':
+  '@pgpmjs/logger@2.23.0':
     dependencies:
       yanse: 0.2.1
 
-  '@pgpmjs/server-utils@3.23.4':
+  '@pgpmjs/portability@0.3.0':
     dependencies:
-      '@pgpmjs/logger': 2.22.1
-      '@pgpmjs/types': 2.48.1
+      '@pgpmjs/core': 7.20.0
+      '@pgpmjs/env': 2.40.0
+      '@pgpmjs/types': 2.49.0
+      pg-env: 1.27.0
+    transitivePeerDependencies:
+      - pg-native
+      - supports-color
+
+  '@pgpmjs/server-utils@3.24.0':
+    dependencies:
+      '@pgpmjs/logger': 2.23.0
+      '@pgpmjs/types': 2.49.0
       cors: 2.8.6
       express: 5.2.1
       lru-cache: 11.5.2
     transitivePeerDependencies:
       - supports-color
 
-  '@pgpmjs/slice@0.12.0':
+  '@pgpmjs/slice@0.13.0':
     dependencies:
-      '@pgpmjs/ast': 0.9.5
-      '@pgpmjs/transform': 0.13.0
+      '@pgpmjs/ast': 0.10.0
+      '@pgpmjs/transform': 0.14.0
       minimatch: 10.2.6
       plpgsql-parser: 18.2.2
     transitivePeerDependencies:
       - supports-color
 
-  '@pgpmjs/transform@0.13.0':
+  '@pgpmjs/transform@0.14.0':
     dependencies:
       '@pgsql/transform': 18.8.0
       plpgsql-parser: 18.2.2
     transitivePeerDependencies:
       - supports-color
 
-  '@pgpmjs/traverse@0.9.5':
+  '@pgpmjs/traverse@0.10.0':
     dependencies:
-      '@pgpmjs/ast': 0.9.5
+      '@pgpmjs/ast': 0.10.0
 
-  '@pgpmjs/types@2.48.1':
+  '@pgpmjs/types@2.49.0':
     dependencies:
-      '@constructive-io/errors': 0.7.2
-      pg-env: 1.26.1
+      '@constructive-io/errors': 0.8.0
+      pg-env: 1.27.0
 
   '@pgsql/quotes@18.1.0': {}
 
@@ -5639,7 +5655,7 @@ snapshots:
 
   csv-parser@3.2.1: {}
 
-  csv-to-pg@4.8.1:
+  csv-to-pg@4.9.0:
     dependencies:
       '@pgsql/types': 18.0.0
       '@pgsql/utils': 18.1.1
@@ -7492,14 +7508,14 @@ snapshots:
     dependencies:
       pify: 3.0.0
 
-  pg-cache@3.23.4:
+  pg-cache@3.24.0:
     dependencies:
-      12factor-env: 1.25.1
-      '@pgpmjs/logger': 2.22.1
-      '@pgpmjs/types': 2.48.1
+      12factor-env: 1.26.0
+      '@pgpmjs/logger': 2.23.0
+      '@pgpmjs/types': 2.49.0
       lru-cache: 11.5.2
       pg: 8.22.0
-      pg-env: 1.26.1
+      pg-env: 1.27.0
     transitivePeerDependencies:
       - pg-native
 
@@ -7510,9 +7526,9 @@ snapshots:
 
   pg-copy-streams@7.0.0: {}
 
-  pg-env@1.26.1:
+  pg-env@1.27.0:
     dependencies:
-      12factor-env: 1.25.1
+      12factor-env: 1.26.0
 
   pg-int8@1.0.1: {}
 
@@ -7536,7 +7552,7 @@ snapshots:
 
   pg-protocol@1.15.0: {}
 
-  pg-seed@0.25.1:
+  pg-seed@0.26.0:
     dependencies:
       csv-parse: 6.2.1
       pg: 8.22.0
@@ -7566,13 +7582,13 @@ snapshots:
     dependencies:
       split2: 4.2.0
 
-  pgsql-client@4.8.7:
+  pgsql-client@4.9.0:
     dependencies:
-      '@pgpmjs/core': 7.18.0
-      '@pgpmjs/logger': 2.22.1
-      '@pgpmjs/types': 2.48.1
+      '@pgpmjs/core': 7.20.0
+      '@pgpmjs/logger': 2.23.0
+      '@pgpmjs/types': 2.49.0
       pg: 8.22.0
-      pg-env: 1.26.1
+      pg-env: 1.27.0
     transitivePeerDependencies:
       - pg-native
       - supports-color
@@ -7588,28 +7604,28 @@ snapshots:
       libpg-query: 18.1.2
       pgsql-deparser: 18.1.1
 
-  pgsql-seed@3.8.7:
+  pgsql-seed@3.9.0:
     dependencies:
-      '@pgpmjs/core': 7.18.0
-      '@pgpmjs/env': 2.39.2
+      '@pgpmjs/core': 7.20.0
+      '@pgpmjs/env': 2.40.0
       pg: 8.22.0
-      pg-env: 1.26.1
-      pg-seed: 0.25.1
+      pg-env: 1.27.0
+      pg-seed: 0.26.0
     transitivePeerDependencies:
       - pg-native
       - supports-color
 
-  pgsql-test@5.8.7:
+  pgsql-test@5.9.0:
     dependencies:
-      '@pgpmjs/env': 2.39.2
-      '@pgpmjs/logger': 2.22.1
-      '@pgpmjs/server-utils': 3.23.4
-      '@pgpmjs/types': 2.48.1
+      '@pgpmjs/env': 2.40.0
+      '@pgpmjs/logger': 2.23.0
+      '@pgpmjs/server-utils': 3.24.0
+      '@pgpmjs/types': 2.49.0
       pg: 8.22.0
-      pg-cache: 3.23.4
-      pg-env: 1.26.1
-      pgsql-client: 4.8.7
-      pgsql-seed: 3.8.7
+      pg-cache: 3.24.0
+      pg-env: 1.27.0
+      pgsql-client: 4.9.0
+      pgsql-seed: 3.9.0
     transitivePeerDependencies:
       - pg-native
       - supports-color
@@ -8049,12 +8065,12 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  supabase-test@3.8.7:
+  supabase-test@3.9.0:
     dependencies:
-      '@pgpmjs/types': 2.48.1
+      '@pgpmjs/types': 2.49.0
       deepmerge: 4.3.1
-      pg-env: 1.26.1
-      pgsql-test: 5.8.7
+      pg-env: 1.27.0
+      pgsql-test: 5.9.0
     transitivePeerDependencies:
       - pg-native
       - supports-color

--- a/portability/materialized/README.md
+++ b/portability/materialized/README.md
@@ -1,0 +1,44 @@
+# Materialized (ejected) vendor modules
+
+These are the **committed output** of the apply proxies under `../packages`.
+
+An apply proxy (`pgpm.apply.json` + the `supabase` vendor shape) is a *recipe*:
+it transforms a source module into a new shape at deploy time. Running
+`pgpm materialize` / `materializeApplyModule` on that recipe **ejects** the
+result into an ordinary pgpm module — plain `deploy/ revert/ verify/ pgpm.plan /
+*.control`, with every transform already baked into the SQL and no
+`pgpm.apply.json`. Once ejected, it deploys like any hand-written module.
+
+Both directions are ejected here:
+
+| Module | Direction | What it proves |
+|---|---|---|
+| `packages/vendor-app-materialized` | Supabase shape → pgpm shape | auth subsystem excluded; FK + RLS rebound onto the generic `app_auth` provider; `extensions.uuid_generate_v4()` de-qualified to a bare `uuid_generate_v4()` from the `uuid-ossp` extension the module installs itself (both provider + extension declared in its control `requires`) |
+| `packages/vendor-app-native-materialized` | pgpm shape → Supabase shape | references routed back onto the native `auth.users` / `auth.uid()`; extension calls re-qualified into the `extensions` schema; deploys on top of the `supabase` fixture module |
+
+## Regenerating
+
+The modules are generated (and their `requires` finalized) by the committed
+recipe in the test package:
+
+```bash
+cd ../packages/portability-tests
+pnpm exec ts-node src/materialize-fixtures.ts
+```
+
+Materialization is deterministic, so `__tests__/materialized-drift.test.ts` is
+the drift gate: it re-materializes into a temp dir and asserts byte-identical
+output against what is committed here. If a source module, the vendor shape, or
+the transform engine changes the emitted SQL, that test fails until these
+artifacts are regenerated and reviewed.
+
+## Testing
+
+- `__tests__/materialized-forward.test.ts` deploys and exercises the forward
+  module on **plain PostgreSQL** (the generic provider, no vendor image).
+- `__tests__/materialized-reverse.test.ts` deploys and exercises the reverse
+  module on the **vendor stack** (`VENDOR_STACK=1`), because the native Supabase
+  subsystem it targets needs Supabase-only extensions (`pg_graphql`,
+  `supabase_vault`) unavailable on plain PostgreSQL. The determinism and the
+  ejected SQL for this direction are still verified on plain PG by the drift
+  gate.

--- a/portability/materialized/packages/vendor-app-materialized/deploy/schemas/app/policies/documents_owner.sql
+++ b/portability/materialized/packages/vendor-app-materialized/deploy/schemas/app/policies/documents_owner.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+ALTER TABLE app.documents 
+  ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY documents_owner
+  ON app.documents
+  AS PERMISSIVE
+  FOR ALL
+  TO PUBLIC
+  USING (
+    owner = app_auth.current_user_id()
+  );
+
+COMMIT;

--- a/portability/materialized/packages/vendor-app-materialized/deploy/schemas/app/schema.sql
+++ b/portability/materialized/packages/vendor-app-materialized/deploy/schemas/app/schema.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+CREATE SCHEMA app;
+
+GRANT USAGE ON SCHEMA app TO authenticated;
+
+COMMIT;

--- a/portability/materialized/packages/vendor-app-materialized/deploy/schemas/app/tables/documents/table.sql
+++ b/portability/materialized/packages/vendor-app-materialized/deploy/schemas/app/tables/documents/table.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+CREATE TABLE app.documents (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  owner uuid NOT NULL,
+  title text NOT NULL
+);
+
+ALTER TABLE app.documents 
+  ADD CONSTRAINT documents_owner_fkey
+    FOREIGN KEY(owner)
+    REFERENCES app_auth.users (id);
+
+GRANT SELECT, INSERT ON app.documents TO authenticated;
+
+COMMIT;

--- a/portability/materialized/packages/vendor-app-materialized/pgpm.plan
+++ b/portability/materialized/packages/vendor-app-materialized/pgpm.plan
@@ -1,0 +1,7 @@
+%syntax-version=1.0.0
+%project=vendor-app-materialized
+%uri=vendor-app-materialized
+
+schemas/app/schema 2024-01-01T00:00:03Z Dev <dev@example.com> # add app schema
+schemas/app/tables/documents/table [schemas/app/schema] 2024-01-01T00:00:04Z Dev <dev@example.com> # add documents table
+schemas/app/policies/documents_owner [schemas/app/tables/documents/table] 2024-01-01T00:00:05Z Dev <dev@example.com> # add documents policy

--- a/portability/materialized/packages/vendor-app-materialized/revert/schemas/app/policies/documents_owner.sql
+++ b/portability/materialized/packages/vendor-app-materialized/revert/schemas/app/policies/documents_owner.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP POLICY documents_owner ON app.documents;
+
+COMMIT;

--- a/portability/materialized/packages/vendor-app-materialized/revert/schemas/app/schema.sql
+++ b/portability/materialized/packages/vendor-app-materialized/revert/schemas/app/schema.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP SCHEMA app;
+
+COMMIT;

--- a/portability/materialized/packages/vendor-app-materialized/revert/schemas/app/tables/documents/table.sql
+++ b/portability/materialized/packages/vendor-app-materialized/revert/schemas/app/tables/documents/table.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE app.documents;
+
+COMMIT;

--- a/portability/materialized/packages/vendor-app-materialized/vendor-app-materialized.control
+++ b/portability/materialized/packages/vendor-app-materialized/vendor-app-materialized.control
@@ -1,0 +1,7 @@
+# vendor-app extension
+comment = 'vendor-app extension'
+default_version = '0.0.1'
+module_pathname = '$libdir/vendor-app'
+requires = 'plpgsql, uuid-ossp, auth-provider'
+relocatable = false
+superuser = false

--- a/portability/materialized/packages/vendor-app-materialized/verify/schemas/app/policies/documents_owner.sql
+++ b/portability/materialized/packages/vendor-app-materialized/verify/schemas/app/policies/documents_owner.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+SELECT owner
+FROM app.documents
+WHERE
+  false;
+
+ROLLBACK;

--- a/portability/materialized/packages/vendor-app-materialized/verify/schemas/app/schema.sql
+++ b/portability/materialized/packages/vendor-app-materialized/verify/schemas/app/schema.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+SELECT pg_catalog.has_schema_privilege('app', 'usage');
+
+ROLLBACK;

--- a/portability/materialized/packages/vendor-app-materialized/verify/schemas/app/tables/documents/table.sql
+++ b/portability/materialized/packages/vendor-app-materialized/verify/schemas/app/tables/documents/table.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+SELECT
+  id,
+  owner,
+  title
+FROM app.documents
+WHERE
+  false;
+
+ROLLBACK;

--- a/portability/materialized/packages/vendor-app-native-materialized/deploy/schemas/app/policies/documents_owner.sql
+++ b/portability/materialized/packages/vendor-app-native-materialized/deploy/schemas/app/policies/documents_owner.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+ALTER TABLE app.documents 
+  ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY documents_owner
+  ON app.documents
+  AS PERMISSIVE
+  FOR ALL
+  TO PUBLIC
+  USING (
+    owner = auth.uid()
+  );
+
+COMMIT;

--- a/portability/materialized/packages/vendor-app-native-materialized/deploy/schemas/app/schema.sql
+++ b/portability/materialized/packages/vendor-app-native-materialized/deploy/schemas/app/schema.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+CREATE SCHEMA app;
+
+GRANT USAGE ON SCHEMA app TO authenticated;
+
+COMMIT;

--- a/portability/materialized/packages/vendor-app-native-materialized/deploy/schemas/app/tables/documents/table.sql
+++ b/portability/materialized/packages/vendor-app-native-materialized/deploy/schemas/app/tables/documents/table.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+CREATE TABLE app.documents (
+  id uuid PRIMARY KEY DEFAULT extensions.uuid_generate_v4(),
+  owner uuid NOT NULL,
+  title text NOT NULL
+);
+
+ALTER TABLE app.documents 
+  ADD CONSTRAINT documents_owner_fkey
+    FOREIGN KEY(owner)
+    REFERENCES auth.users (id);
+
+GRANT SELECT, INSERT ON app.documents TO authenticated;
+
+COMMIT;

--- a/portability/materialized/packages/vendor-app-native-materialized/pgpm.plan
+++ b/portability/materialized/packages/vendor-app-native-materialized/pgpm.plan
@@ -1,0 +1,7 @@
+%syntax-version=1.0.0
+%project=vendor-app-native-materialized
+%uri=vendor-app-native-materialized
+
+schemas/app/schema 2024-01-01T00:00:03Z Dev <dev@example.com> # add app schema
+schemas/app/tables/documents/table [schemas/app/schema] 2024-01-01T00:00:04Z Dev <dev@example.com> # add documents table
+schemas/app/policies/documents_owner [schemas/app/tables/documents/table] 2024-01-01T00:00:05Z Dev <dev@example.com> # add documents policy

--- a/portability/materialized/packages/vendor-app-native-materialized/revert/schemas/app/policies/documents_owner.sql
+++ b/portability/materialized/packages/vendor-app-native-materialized/revert/schemas/app/policies/documents_owner.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP POLICY documents_owner ON app.documents;
+
+COMMIT;

--- a/portability/materialized/packages/vendor-app-native-materialized/revert/schemas/app/schema.sql
+++ b/portability/materialized/packages/vendor-app-native-materialized/revert/schemas/app/schema.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP SCHEMA app;
+
+COMMIT;

--- a/portability/materialized/packages/vendor-app-native-materialized/revert/schemas/app/tables/documents/table.sql
+++ b/portability/materialized/packages/vendor-app-native-materialized/revert/schemas/app/tables/documents/table.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+DROP TABLE app.documents;
+
+COMMIT;

--- a/portability/materialized/packages/vendor-app-native-materialized/vendor-app-native-materialized.control
+++ b/portability/materialized/packages/vendor-app-native-materialized/vendor-app-native-materialized.control
@@ -1,0 +1,7 @@
+# vendor-app extension
+comment = 'vendor-app extension'
+default_version = '0.0.1'
+module_pathname = '$libdir/vendor-app'
+requires = 'plpgsql'
+relocatable = false
+superuser = false

--- a/portability/materialized/packages/vendor-app-native-materialized/verify/schemas/app/policies/documents_owner.sql
+++ b/portability/materialized/packages/vendor-app-native-materialized/verify/schemas/app/policies/documents_owner.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+SELECT owner
+FROM app.documents
+WHERE
+  false;
+
+ROLLBACK;

--- a/portability/materialized/packages/vendor-app-native-materialized/verify/schemas/app/schema.sql
+++ b/portability/materialized/packages/vendor-app-native-materialized/verify/schemas/app/schema.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+SELECT pg_catalog.has_schema_privilege('app', 'usage');
+
+ROLLBACK;

--- a/portability/materialized/packages/vendor-app-native-materialized/verify/schemas/app/tables/documents/table.sql
+++ b/portability/materialized/packages/vendor-app-native-materialized/verify/schemas/app/tables/documents/table.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+SELECT
+  id,
+  owner,
+  title
+FROM app.documents
+WHERE
+  false;
+
+ROLLBACK;

--- a/portability/packages/portability-tests/__tests__/materialized-drift.test.ts
+++ b/portability/packages/portability-tests/__tests__/materialized-drift.test.ts
@@ -1,0 +1,62 @@
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, relative } from 'path';
+
+import { committedRoot, FORWARD_MODULE, materializeAll, REVERSE_MODULE } from '../src/materialize-fixtures';
+
+// The committed modules under `portability/materialized/packages` are a build
+// artifact of the apply proxies. Materialization is deterministic, so this is
+// the drift gate: re-materialize into a temp dir and assert the output is
+// byte-identical to what is committed. If a source module, the vendor shape, or
+// the transform engine changes the emitted SQL, this fails until the artifact
+// is regenerated (`ts-node src/materialize-fixtures.ts`) and reviewed.
+function listFiles(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else out.push(relative(root, full));
+    }
+  };
+  walk(root);
+  return out.sort();
+}
+
+let tmpRoot: string;
+
+beforeAll(async () => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'pgpm-materialize-drift-'));
+  await materializeAll(tmpRoot);
+});
+
+afterAll(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe.each([FORWARD_MODULE, REVERSE_MODULE])('committed materialized module: %s', moduleName => {
+  const committedDir = join(committedRoot, moduleName);
+  // Lazy: tmpRoot is created in beforeAll, after this factory runs at collection.
+  const freshDir = () => join(tmpRoot, moduleName);
+
+  it('is an ordinary pgpm module (no pgpm.apply.json)', () => {
+    expect(existsSync(join(committedDir, 'pgpm.apply.json'))).toBe(false);
+    expect(existsSync(join(committedDir, 'pgpm.plan'))).toBe(true);
+    expect(existsSync(join(committedDir, `${moduleName}.control`))).toBe(true);
+    expect(existsSync(join(committedDir, 'deploy'))).toBe(true);
+    expect(existsSync(join(committedDir, 'revert'))).toBe(true);
+    expect(existsSync(join(committedDir, 'verify'))).toBe(true);
+  });
+
+  it('has the same file set as a fresh materialization', () => {
+    expect(listFiles(committedDir)).toEqual(listFiles(freshDir()));
+  });
+
+  it('is byte-identical to a fresh materialization (no drift)', () => {
+    for (const rel of listFiles(committedDir)) {
+      expect(readFileSync(join(committedDir, rel), 'utf-8')).toBe(
+        readFileSync(join(freshDir(), rel), 'utf-8')
+      );
+    }
+  });
+});

--- a/portability/packages/portability-tests/__tests__/materialized-forward.test.ts
+++ b/portability/packages/portability-tests/__tests__/materialized-forward.test.ts
@@ -1,0 +1,133 @@
+import {
+  generateCreateBaseRolesSQL,
+  generateGrantRoleSQL,
+  PgpmPackage
+} from '@pgpmjs/core';
+import { getEnvOptions } from '@pgpmjs/env';
+import { getConnections, PgTestClient, seed } from 'pgsql-test';
+
+import { FORWARD_MODULE, portabilityRoot } from '../src/materialize-fixtures';
+
+// Forward direction, deployed from the COMMITTED ejected module — not applied
+// at runtime. `portability/materialized/packages/vendor-app-materialized` is an
+// ordinary pgpm module (no `pgpm.apply.json`): Supabase's auth subsystem is
+// already excluded, every reference is already rebound onto the generic
+// provider, and `extensions.uuid_generate_v4()` is already de-qualified to a
+// bare `uuid_generate_v4()`. Deploying it exercises the "materialize once,
+// deploy plain" path — pgpm resolves its `requires` (auth-provider, uuid-ossp)
+// and deploys them first, exactly like any hand-written module.
+const roles = {
+  anonymous: 'anonymous',
+  authenticated: 'authenticated',
+  administrator: 'administrator',
+  default: 'anonymous'
+};
+
+let pg: PgTestClient;
+let db: PgTestClient;
+let teardown: () => Promise<void>;
+
+let aliceId: string;
+
+beforeAll(async () => {
+  ({ pg, db, teardown } = await getConnections({ db: { roles } }, [
+    seed.fn(async ({ pg, connect }) => {
+      await pg.any(generateCreateBaseRolesSQL(connect.roles));
+      const appUser = connect.connections.app.user;
+      for (const role of [
+        connect.roles.anonymous,
+        connect.roles.authenticated,
+        connect.roles.administrator
+      ]) {
+        await pg.any(generateGrantRoleSQL(role, appUser));
+      }
+    }),
+
+    // Deploy the committed, materialized module as a plain pgpm module.
+    seed.fn(async ({ config }) => {
+      await new PgpmPackage(portabilityRoot).deploy(
+        getEnvOptions({ pg: config, deployment: { fast: true, usePlan: true } }),
+        FORWARD_MODULE
+      );
+    }),
+
+    seed.fn(async ({ pg }) => {
+      await pg.any(`GRANT USAGE ON SCHEMA app_auth TO authenticated`);
+      await pg.any(
+        `GRANT EXECUTE ON FUNCTION app_auth.current_user_id() TO authenticated`
+      );
+
+      const [alice] = await pg.any(
+        `INSERT INTO app_auth.users DEFAULT VALUES RETURNING id`
+      );
+      const [bob] = await pg.any(
+        `INSERT INTO app_auth.users DEFAULT VALUES RETURNING id`
+      );
+      aliceId = alice.id;
+      await pg.any(
+        `INSERT INTO app.documents (owner, title) VALUES ($1, 'alice doc')`,
+        [alice.id]
+      );
+      await pg.any(
+        `INSERT INTO app.documents (owner, title) VALUES ($1, 'bob doc')`,
+        [bob.id]
+      );
+    })
+  ]));
+});
+
+afterAll(async () => {
+  await teardown();
+});
+
+beforeEach(async () => {
+  await pg.beforeEach();
+  await db.beforeEach();
+});
+
+afterEach(async () => {
+  await db.afterEach();
+  await pg.afterEach();
+});
+
+describe('committed forward (Supabase → pgpm) module on plain PostgreSQL', () => {
+  it('the excluded auth subsystem is absent from the committed module', async () => {
+    const res = await pg.any(
+      `SELECT 1 FROM information_schema.schemata WHERE schema_name = 'auth'`
+    );
+    expect(res.length).toBe(0);
+  });
+
+  it('has no extensions schema — extension calls were de-qualified', async () => {
+    const res = await pg.any(
+      `SELECT 1 FROM information_schema.schemata WHERE schema_name = 'extensions'`
+    );
+    expect(res.length).toBe(0);
+  });
+
+  it('pulled its provider dependency (app_auth) via the control requires', async () => {
+    const res = await pg.any(
+      `SELECT 1 FROM information_schema.tables WHERE table_schema = 'app_auth' AND table_name = 'users'`
+    );
+    expect(res.length).toBe(1);
+  });
+
+  it('the FK is baked onto the provider users table', async () => {
+    const [{ id }] = await pg.any(
+      `INSERT INTO app_auth.users DEFAULT VALUES RETURNING id`
+    );
+    await pg.any(`INSERT INTO app.documents (owner, title) VALUES ($1, 'mine')`, [id]);
+
+    await expect(
+      pg.any(
+        `INSERT INTO app.documents (owner, title) VALUES (gen_random_uuid(), 'nope')`
+      )
+    ).rejects.toThrow(/foreign key/i);
+  });
+
+  it('enforces RLS through the provider accessor', async () => {
+    db.setContext({ role: 'authenticated', 'jwt.claims.user_id': aliceId });
+    const visible = await db.any(`SELECT title FROM app.documents`);
+    expect(visible.map((r: { title: string }) => r.title)).toEqual(['alice doc']);
+  });
+});

--- a/portability/packages/portability-tests/__tests__/materialized-reverse.test.ts
+++ b/portability/packages/portability-tests/__tests__/materialized-reverse.test.ts
@@ -1,0 +1,84 @@
+import { join } from 'path';
+
+import { PgpmPackage } from '@pgpmjs/core';
+import { getEnvOptions } from '@pgpmjs/env';
+import { getConnections, PgTestClient, seed } from 'supabase-test';
+
+import { portabilityRoot, REVERSE_MODULE } from '../src/materialize-fixtures';
+
+// Reverse direction, deployed from the COMMITTED ejected module against the
+// vendor stack. The pgpm-shaped app was materialized back onto Supabase's
+// native subsystem: the committed SQL in `vendor-app-native-materialized`
+// references `auth.users` / `auth.uid()` and re-qualifies extension calls into
+// `extensions.uuid_generate_v4()`. Those objects only exist on the real stack
+// (the `supabase` fixture needs `pg_graphql`/`supabase_vault`, unavailable on
+// plain postgres-plus), so this suite runs only where the stack is available
+// (VENDOR_STACK=1 in the vendor workflow). Determinism and the ejected SQL for
+// this direction are covered on plain PG by `materialized-drift.test.ts`.
+const suite = process.env.VENDOR_STACK ? describe : describe.skip;
+
+const supabaseDir = join(portabilityRoot, '..', 'packages', 'supabase');
+
+let pg: PgTestClient;
+let teardown: () => Promise<void>;
+
+suite('committed reverse (pgpm → Supabase) module on the vendor stack', () => {
+  beforeAll(async () => {
+    ({ pg, teardown } = await getConnections({}, [
+      // The real vendored fixture deploys first as an ordinary pgpm module,
+      // giving the reverse-transpiled package its native subsystem (auth +
+      // the extensions schema) and doubling as a fixture regression check.
+      seed.pgpm(supabaseDir),
+
+      // Deploy the committed reverse module as a plain pgpm module on top. Its
+      // control `requires` is just plpgsql — the stack owns auth and the
+      // extension schema natively.
+      seed.fn(async ({ config }) => {
+        await new PgpmPackage(portabilityRoot).deploy(
+          getEnvOptions({ pg: config, deployment: { fast: true, usePlan: true } }),
+          REVERSE_MODULE
+        );
+      })
+    ]));
+  });
+
+  afterAll(async () => {
+    await teardown();
+  });
+
+  beforeEach(async () => {
+    await pg.beforeEach();
+  });
+
+  afterEach(async () => {
+    await pg.afterEach();
+  });
+
+  it('the native auth subsystem is present', async () => {
+    const res = await pg.any(
+      `SELECT 1 FROM information_schema.tables WHERE table_schema = 'auth' AND table_name = 'users'`
+    );
+    expect(res.length).toBe(1);
+  });
+
+  it('the FK is baked onto the native users table', async () => {
+    const fk = await pg.any(`
+      SELECT n.nspname || '.' || c.relname AS target
+      FROM pg_constraint con
+      JOIN pg_class c ON c.oid = con.confrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE con.conname = 'documents_owner_fkey'
+    `);
+    expect(fk[0].target).toBe('auth.users');
+  });
+
+  it('the RLS predicate is baked onto the native accessor', async () => {
+    const policy = await pg.any(`
+      SELECT pg_get_expr(polqual, polrelid) AS predicate
+      FROM pg_policy
+      WHERE polname = 'documents_owner'
+    `);
+    expect(policy[0].predicate).toMatch(/\buid\(\)/);
+    expect(policy[0].predicate).not.toMatch(/current_user_id/);
+  });
+});

--- a/portability/packages/portability-tests/package.json
+++ b/portability/packages/portability-tests/package.json
@@ -10,14 +10,15 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@pgpmjs/core": "7.18.0",
-    "@pgpmjs/env": "2.39.2",
-    "@pgpmjs/slice": "0.12.0",
-    "@pgpmjs/transform": "0.13.0",
-    "@pgpmjs/types": "2.48.1",
-    "pgsql-test": "^5.8.7",
-    "supabase-test": "^3.8.7",
-    "@pgpmjs/bundle": "^0.12.4"
+    "@pgpmjs/bundle": "^0.13.0",
+    "@pgpmjs/core": "7.20.0",
+    "@pgpmjs/env": "2.40.0",
+    "@pgpmjs/portability": "0.3.0",
+    "@pgpmjs/slice": "0.13.0",
+    "@pgpmjs/transform": "0.14.0",
+    "@pgpmjs/types": "2.49.0",
+    "pgsql-test": "^5.9.0",
+    "supabase-test": "^3.9.0"
   },
   "keywords": []
 }

--- a/portability/packages/portability-tests/src/materialize-fixtures.ts
+++ b/portability/packages/portability-tests/src/materialize-fixtures.ts
@@ -1,0 +1,155 @@
+/**
+ * Regenerate the committed, materialized ("ejected") vendor modules under
+ * `portability/materialized/packages`.
+ *
+ * The apply proxies under `portability/packages` are the *recipe*; the plain
+ * modules in `portability/materialized/packages` are their committed *output* —
+ * ordinary pgpm modules with the transforms baked into the SQL (no
+ * `pgpm.apply.json`, no deploy-time apply). Every transform is derived from the
+ * `supabase` vendor shape, not hand-written routing, so the ejected modules
+ * stay a query away from the shape declaration.
+ *
+ * Materialization is deterministic: identical source + spec always produce a
+ * byte-identical bundle, which is what lets `materialized-drift.test.ts` re-run
+ * this and assert the committed output has not drifted.
+ *
+ * Regenerate the committed output with:
+ *
+ *   pnpm --filter @pgpm/portability-tests exec ts-node src/materialize-fixtures.ts
+ */
+import { materializeApplyModule, parseApplySpec } from '@pgpmjs/core';
+import {
+  fromVendorProfile,
+  ProviderBinding,
+  supabase,
+  toVendorProfile
+} from '@pgpmjs/portability';
+import { readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+/** The generic provider that substitutes Supabase's managed auth subsystem. */
+const provider: ProviderBinding = {
+  schema: 'app_auth',
+  users: 'users',
+  accessors: { uid: 'current_user_id' }
+};
+
+// package root: portability/packages/portability-tests
+const packageRoot = join(__dirname, '..');
+export const portabilityRoot = join(packageRoot, '..', '..');
+export const vendorAppDir = join(portabilityRoot, 'packages', 'vendor-app');
+export const committedRoot = join(portabilityRoot, 'materialized', 'packages');
+
+export const FORWARD_MODULE = 'vendor-app-materialized';
+export const REVERSE_MODULE = 'vendor-app-native-materialized';
+
+// Supabase shape → pgpm shape: exclude the auth subsystem, rebind survivors
+// onto the generic provider, and de-qualify the `extensions` schema so
+// `extensions.uuid_generate_v4()` becomes a bare `uuid_generate_v4()` resolved
+// from the `uuid-ossp` extension the ejected module installs itself.
+const forwardSpec = () =>
+  parseApplySpec(
+    JSON.stringify({
+      source: 'vendor-app',
+      name: FORWARD_MODULE,
+      ...fromVendorProfile(supabase, provider),
+      requires: ['auth-provider', 'uuid-ossp']
+    }),
+    '/spec/pgpm.apply.json'
+  );
+
+// pgpm shape → Supabase shape: the inverse binding, routing the provider's
+// objects back onto Supabase's native `auth` subsystem and re-qualifying
+// extension symbols into the `extensions` schema the stack owns.
+const reverseSpec = () =>
+  parseApplySpec(
+    JSON.stringify({
+      source: FORWARD_MODULE,
+      name: REVERSE_MODULE,
+      ...toVendorProfile(supabase, provider),
+      requires: []
+    }),
+    '/spec/pgpm.apply.json'
+  );
+
+/**
+ * Declare a module dependency in the ejected module's `.control` `requires`.
+ *
+ * The apply spec's `requires` names the transpiled output's runtime deps, but
+ * `materializeApplyModule` does not yet fold them into the emitted control — so
+ * a plainly-deployed ejected module would not pull its provider. Recording it
+ * here keeps the ejected module self-contained: `pgpm deploy
+ * vendor-app-materialized` resolves and deploys `auth-provider` first, exactly
+ * as `seed.apply` does for the proxy. Deterministic and idempotent, so the
+ * drift check stays byte-stable.
+ */
+function rewriteControlRequires(
+  moduleDir: string,
+  moduleName: string,
+  rewrite: (deps: string[]) => string[]
+): void {
+  const controlPath = join(moduleDir, `${moduleName}.control`);
+  const content = readFileSync(controlPath, 'utf-8');
+  const updated = content.replace(
+    /^(\s*requires\s*=\s*')([^']*)(')/m,
+    (_m, prefix: string, list: string, suffix: string) => {
+      const parts = list
+        .split(',')
+        .map(p => p.trim())
+        .filter(Boolean);
+      return `${prefix}${rewrite(parts).join(', ')}${suffix}`;
+    }
+  );
+  writeFileSync(controlPath, updated);
+}
+
+export async function materializeForward(outRoot: string): Promise<string> {
+  const outDir = join(outRoot, FORWARD_MODULE);
+  rmSync(outDir, { recursive: true, force: true });
+  await materializeApplyModule({ sourceDir: vendorAppDir, spec: forwardSpec(), outDir });
+  // Self-contained forward module: it targets the generic provider and installs
+  // `uuid-ossp` itself (carried from the source control) now that extension
+  // calls are de-qualified.
+  rewriteControlRequires(outDir, FORWARD_MODULE, deps =>
+    deps.includes('auth-provider') ? deps : [...deps, 'auth-provider']
+  );
+  return outDir;
+}
+
+export async function materializeReverse(
+  outRoot: string,
+  forwardDir: string
+): Promise<string> {
+  const outDir = join(outRoot, REVERSE_MODULE);
+  rmSync(outDir, { recursive: true, force: true });
+  await materializeApplyModule({ sourceDir: forwardDir, spec: reverseSpec(), outDir });
+  // The reverse module targets Supabase's *native* subsystem (the `supabase`
+  // fixture, deployed alongside — not part of this workspace), which owns both
+  // `auth` and the `extensions` schema. So it drops the forward source's
+  // provider (`auth-provider`) and extension (`uuid-ossp`) requirements.
+  rewriteControlRequires(outDir, REVERSE_MODULE, deps =>
+    deps.filter(d => d !== 'auth-provider' && d !== 'uuid-ossp')
+  );
+  return outDir;
+}
+
+export async function materializeAll(
+  outRoot: string
+): Promise<{ forward: string; reverse: string }> {
+  const forward = await materializeForward(outRoot);
+  const reverse = await materializeReverse(outRoot, forward);
+  return { forward, reverse };
+}
+
+if (require.main === module) {
+  materializeAll(committedRoot)
+    .then(r => {
+      // eslint-disable-next-line no-console
+      console.log(`materialized:\n  ${r.forward}\n  ${r.reverse}`);
+    })
+    .catch(err => {
+      // eslint-disable-next-line no-console
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/portability/pgpm.json
+++ b/portability/pgpm.json
@@ -1,6 +1,7 @@
 {
   "packages": [
-    "packages/*"
+    "packages/*",
+    "materialized/packages/*"
   ],
   "db": {
     "roles": {


### PR DESCRIPTION
## Summary

Bumps `@pgpmjs/*` + `supabase-test` to the freshly published versions (core `7.20.0`, portability `0.3.0`, `supabase-test` `3.9.0`, …) and adds **persistent, committed materialized ("ejected") vendor modules in both directions**, kept in a separate `portability/materialized/` tree so they don't clutter the source fixtures in `portability/packages/`.

Until now the transform only ran *at deploy time* (`seed.apply`) — nothing landed on disk to review. This ejects the apply proxies into ordinary pgpm modules (`deploy/ revert/ verify/ pgpm.plan / *.control`, **no `pgpm.apply.json`**) with the transforms baked into the SQL, so they deploy like any hand-written module. Every transform is derived from the `supabase` vendor shape (`fromVendorProfile` / `toVendorProfile`), not hand-written routing.

```
portability/
├── packages/                     # source fixtures + apply proxies (recipes)
└── materialized/packages/        # committed ejected output (build artifact)
    ├── vendor-app-materialized/          # Supabase → pgpm
    └── vendor-app-native-materialized/   # pgpm → Supabase
```

**What each direction bakes in:**

| Module | requires | FK | RLS predicate | `uuid_generate_v4` |
|---|---|---|---|---|
| `vendor-app-materialized` (fwd) | `plpgsql, uuid-ossp, auth-provider` | `app_auth.users` | `app_auth.current_user_id()` | de-qualified (bare) |
| `vendor-app-native-materialized` (rev) | `plpgsql` | `auth.users` | `auth.uid()` | re-qualified `extensions.uuid_generate_v4()` |

**Tests added (run serially):**
- `materialized-drift.test.ts` — the drift gate on **plain PostgreSQL**: re-materializes into a temp dir and asserts **byte-identical** output vs. what's committed (both directions), plus asserts each module is a plain pgpm module (no `pgpm.apply.json`).
- `materialized-forward.test.ts` — deploys the committed forward module on **plain PostgreSQL** (`PgpmPackage.deploy` resolves `auth-provider` + `uuid-ossp` first) and asserts `auth`/`extensions` schemas are absent, the FK/RLS are rebound onto the generic provider, and RLS is enforced through `app_auth.current_user_id()`.
- `materialized-reverse.test.ts` — deploys Supabase's native `supabase` fixture, then the committed reverse module on top, asserting the FK/RLS rebind back onto `auth.users` / `auth.uid()`. **Gated behind `VENDOR_STACK=1`** (the vendor workflow) because the native subsystem needs Supabase-only extensions (`pg_graphql`, `supabase_vault`) unavailable on plain `postgres-plus`; the ejected SQL and its determinism for this direction are still verified on plain PG by the drift gate.

`src/materialize-fixtures.ts` is the committed generator (`materializeApplyModule` over the vendor-shape specs) used both to regenerate the artifacts and by the drift test. It also finalizes the ejected `.control` `requires` (forward adds `auth-provider`, keeps `uuid-ossp`; reverse drops both — the stack owns `auth` and the `extensions` schema natively), since `materializeApplyModule` does not yet fold apply-spec `requires` into the emitted control.

`portability/pgpm.json` now globs `materialized/packages/*` so the ejected modules are discoverable for plain deployment.

**Local:** on `postgres-plus:18`, 20 tests pass + 4 skipped (the vendor-stack reverse/deploy suites gate off without `VENDOR_STACK`).


Link to Devin session: https://app.devin.ai/sessions/025fb88043964fdbb335ac5e39df2478
Requested by: @pyramation