### PR TITLE
Add pnpm supply-chain policy (recipe A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Install
         run: pnpm install
 
+      - name: Check supply-chain policy
+        run: pnpm run policy:check
+
       - name: Install pgpm CLI globally
         run: npm install -g pgpm
 

--- a/package.json
+++ b/package.json
@@ -18,9 +18,12 @@
     "bundle": "pnpm -r bundle",
     "lint": "pnpm -r lint",
     "test": "pnpm -r test",
-    "deps": "pnpm up -r -i -L"
+    "deps": "pnpm up -r -i -L",
+    "policy": "pnpm-policy generate",
+    "policy:check": "pnpm-policy check"
   },
   "devDependencies": {
+    "@constructive-io/pnpm-policy": "0.2.1",
     "@types/jest": "^30.0.0",
     "@types/jest-in-case": "^1.0.9",
     "@types/node": "^22.19.11",
@@ -33,6 +36,7 @@
     "jest": "^30.4.2",
     "jest-in-case": "^1.0.2",
     "lerna": "^8.2.3",
+    "pnpm-policy": "^0.2.2",
     "prettier": "^3.8.1",
     "rimraf": "^6.1.3",
     "supabase-test": "^3.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@constructive-io/pnpm-policy':
+        specifier: 0.2.1
+        version: 0.2.1
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -44,6 +47,9 @@ importers:
       lerna:
         specifier: ^8.2.3
         version: 8.2.4(@types/node@22.20.1)(encoding@0.1.13)
+      pnpm-policy:
+        specifier: ^0.2.2
+        version: 0.2.2
       prettier:
         specifier: ^3.8.1
         version: 3.9.6
@@ -277,6 +283,9 @@ packages:
 
   '@constructive-io/errors@0.8.0':
     resolution: {integrity: sha512-HoBaM+41XxV2OzYeVrc7Cxs0ndSCI9mikWukYlCCOuIrQ7aeWyZ8Imy3CGcw+QEwmmhquDVWZGUYR4z5Zkm7eQ==}
+
+  '@constructive-io/pnpm-policy@0.2.1':
+    resolution: {integrity: sha512-tAgH3Zgwn2shQXGlfl5zxmtY/tyZw9jYX7QAOFMp5ALKSrxO5xsxZQmckwMqOeHyyV/MZJWzIZ4t/QYznJeVmw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -2726,6 +2735,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   modify-values@1.0.1:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
     engines: {node: '>=0.10.0'}
@@ -2765,6 +2779,9 @@ packages:
 
   nested-obj@0.2.2:
     resolution: {integrity: sha512-M1etu+T6Ai9Bo06L3K3nWD0ytZWltggBGsrxJlOGvMNGlCA4fokUVlbPKoWzsiiRX+PXq6Cb1xFEn4chiyC7MQ==}
+
+  nested-obj@0.2.3:
+    resolution: {integrity: sha512-Py9HdJ/qECkQHvryUaPcaIou6t+U/mkpT66jG8al7jh8Opt3wAuTSSXdPDyY8r1ljEH8a0EH6M4YR28b+RQ8zg==}
 
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
@@ -3128,6 +3145,10 @@ packages:
 
   plpgsql-parser@18.2.2:
     resolution: {integrity: sha512-XzuvvbZredJeLp3ByOOcNbHthB7kmyi2a/D9vWgyLy7UZBQGP869KziBCeB1TruPRm2JgkC50B2msi3lXZ+DNA==}
+
+  pnpm-policy@0.2.2:
+    resolution: {integrity: sha512-Fj5/ACIZG/AGynTvhT8/7fJTf8ya3jG/Mkq/OMNVZhfTTJ1oniRTsKBHlXGF4sSecvIFqkmeHpn8CsQFwGcENA==}
+    hasBin: true
 
   postcss-selector-parser@6.1.4:
     resolution: {integrity: sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==}
@@ -3851,6 +3872,9 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yamlize@0.12.1:
+    resolution: {integrity: sha512-rU2BN+gmyr0A4yK5i/Ps9JO1MjQGIGUelkaFglc9i4QqEDKU5HfDMdHhNhGMoeNeVw7nJqWpmDiFnxGb6FR5zA==}
+
   yanse@0.2.1:
     resolution: {integrity: sha512-SMi3ZO1IqsvPLLXuy8LBCP1orqcjOT8VygiuyAlplaGeH2g+n4ZSSyWlA/BZjuUuN58TyOcz89mVkflSqIPxxQ==}
 
@@ -4095,6 +4119,8 @@ snapshots:
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@constructive-io/errors@0.8.0': {}
+
+  '@constructive-io/pnpm-policy@0.2.1': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -7140,6 +7166,8 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
+  mkdirp@3.0.1: {}
+
   modify-values@1.0.1: {}
 
   ms@2.1.3: {}
@@ -7167,6 +7195,8 @@ snapshots:
   neo-async@2.6.2: {}
 
   nested-obj@0.2.2: {}
+
+  nested-obj@0.2.3: {}
 
   node-fetch@2.6.7(encoding@0.1.13):
     dependencies:
@@ -7664,6 +7694,11 @@ snapshots:
       plpgsql-deparser: 18.1.2
     transitivePeerDependencies:
       - supports-color
+
+  pnpm-policy@0.2.2:
+    dependencies:
+      yaml: 2.9.0
+      yamlize: 0.12.1
 
   postcss-selector-parser@6.1.4:
     dependencies:
@@ -8398,6 +8433,12 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@2.9.0: {}
+
+  yamlize@0.12.1:
+    dependencies:
+      mkdirp: 3.0.1
+      nested-obj: 0.2.3
+      yaml: 2.9.0
 
   yanse@0.2.1: {}
 

--- a/pnpm-policy.yaml
+++ b/pnpm-policy.yaml
@@ -1,0 +1,42 @@
+# Supply-chain policy for this workspace. The pnpm settings it produces live in
+# pnpm-workspace.yaml under the `Managed by pnpm-policy` marker — edit this file,
+# then run `pnpm run policy`. `pnpm run policy:check` fails CI when they drift.
+
+# Third-party releases wait two days. A compromised release is normally reported
+# and yanked within hours, so the short wait catches it without stalling upgrades.
+minimumReleaseAge: 2d
+
+# Transitive dependencies must resolve from the registry, not from git or a URL.
+blockExoticSubdeps: true
+
+# The npm accounts WE publish under. Everything they publish skips the wait, so
+# this lists accounts we control — nobody else's.
+maintainers:
+  - pyramation
+
+# Scopes we own outright, emitted as `@scope/*` globs so they also cover packages
+# published there tomorrow.
+scopes:
+  - "@constructive-io"
+  - "@constructive-db"
+  - "@launchql"
+  - "@pgpm"
+  - "@pgpmjs"
+  - "@pgsql"
+
+# Resolved from the pinned data package rather than regenerated per repo.
+inventory: "@constructive-io/pnpm-policy/inventory.json"
+
+# Only emit the first-party names this lockfile actually resolves, instead of all
+# ~1100 we publish.
+intersect: true
+
+# Dependencies allowed to run install scripts. The value is the reason.
+allowBuilds:
+  "@launchql/protobufjs": postinstall checks for the optional native encoding helpers (bytebuffer/long) protobufjs uses for perf and prints a warning when they're absent; no code generation or network access happens.
+  nx: postinstall (bin/post-install) downloads the platform-specific @nx/nx-<os>-<arch> native binary the task-graph engine requires to run at all.
+  unrs-resolver: postinstall selects/loads the prebuilt napi-rs native binding for the current platform; the resolver package has no pure-JS fallback.
+
+# Third-party escape hatches. A reason is required; `until` expires the waiver so
+# `check` makes you re-justify it instead of letting it live forever.
+exceptions: []

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,52 @@
 packages:
   - 'packages/*'
   - 'portability/packages/*'
+
+# Exempt from the wait: 6 scope glob(s), 24 first-party package(s).
+# First-party membership comes from what pyramation publishes on npm — waiting on your own release protects nothing.
+minimumReleaseAgeExclude:
+  - "@constructive-db/*"
+  - "@constructive-io/*"
+  - "@launchql/*"
+  - "@pgpm/*"
+  - "@pgpmjs/*"
+  - "@pgsql/*"
+  - 12factor-env
+  - appstash
+  - csv-to-pg
+  - find-and-require-package-json
+  - genomic
+  - inquirerer
+  - libpg-query
+  - nested-obj
+  - pg-cache
+  - pg-env
+  - pg-proto-parser
+  - pg-seed
+  - pgsql-client
+  - pgsql-deparser
+  - pgsql-parser
+  - pgsql-seed
+  - pgsql-test
+  - plpgsql-deparser
+  - plpgsql-parser
+  - pnpm-policy
+  - strfy-js
+  - supabase-test
+  - yamlize
+  - yanse
+
+# Managed by pnpm-policy — run `pnpm-policy generate` after editing pnpm-policy.yaml.
+
+# A third-party release must be 2d old before it can be installed.
+# Most malicious releases are found and yanked well inside that window.
+minimumReleaseAge: 2880
+
+# Transitive dependencies must come from the registry, not from git or a URL.
+blockExoticSubdeps: true
+
+# The only dependencies permitted to run install scripts.
+allowBuilds:
+  "@launchql/protobufjs": true # postinstall checks for the optional native encoding helpers (bytebuffer/long) protobufjs uses for perf and prints a warning when they're absent; no code generation or network access happens.
+  nx: true # postinstall (bin/post-install) downloads the platform-specific @nx/nx-<os>-<arch> native binary the task-graph engine requires to run at all.
+  unrs-resolver: true # postinstall selects/loads the prebuilt napi-rs native binding for the current platform; the resolver package has no pure-JS fallback.


### PR DESCRIPTION
## What

Adds the org-wide pnpm supply-chain policy to this repo, per the recipe in constructive-io/constructive-planning#1464.

- `pnpm-policy.yaml` at the workspace root: the human-edited source of truth.
- `pnpm-workspace.yaml` gets a `minimumReleaseAge: 2d` gate on third-party packages (first-party scopes/packages we publish are exempted — see `minimumReleaseAgeExclude`, derived automatically from what this lockfile actually resolves), plus an `allowBuilds` map for the packages allowed to run install scripts.
- `pnpm run policy` (regenerate) and `pnpm run policy:check` (drift check, wired into CI) scripts added.
- `@constructive-io/pnpm-policy` pinned to an exact `0.2.1` (no caret); `pnpm-policy` added as the CLI devDependency.

## Why 2 days

A compromised release is normally reported and yanked within hours, so a short wait catches it without meaningfully stalling upgrades.

## allowBuilds set

This repo had no `onlyBuiltDependencies` entries to carry over (none existed before this change). `pnpm install` flagged 3 packages under `ERR_PNPM_IGNORED_BUILDS`, now explicitly approved with real reasons:

| Package | Reason |
|---|---|
| `@launchql/protobufjs` | postinstall checks for the optional native encoding helpers (bytebuffer/long) protobufjs uses for perf and prints a warning when they're absent; no code generation or network access happens. |
| `nx` | postinstall (`bin/post-install`) downloads the platform-specific `@nx/nx-<os>-<arch>` native binary the task-graph engine requires to run at all. |
| `unrs-resolver` | postinstall selects/loads the prebuilt napi-rs native binding for the current platform; the resolver package has no pure-JS fallback. |

## blockExoticSubdeps

Left `true` (default). No git- or URL-sourced dependencies found in `pnpm-lock.yaml`.

## CI

Wired into the existing `Supabase tests` job in `.github/workflows/ci.yml`, immediately after the `pnpm install` step:
```yaml
      - name: Check supply-chain policy
        run: pnpm run policy:check
```

## Deviation to flag

This repo's CI (`.github/workflows/ci.yml` and `portability.yml`) pins `pnpm/action-setup@v2` with `version: 9`. The `allowBuilds` key in `pnpm-workspace.yaml` is native pnpm functionality introduced around pnpm 10.16 — pnpm 9 predates the "ignored build scripts" approval gate entirely. Locally (pnpm 11.11.0, no `packageManager` field pins this repo to an older version), only `allowBuilds` actually satisfies `ERR_PNPM_IGNORED_BUILDS` — the older `onlyBuiltDependencies` key was tried first per the pnpm-policy tool's `--builds-key` compat flag, but pnpm 11 ignored it and still blocked the three packages' scripts until `allowBuilds` was added. Since this repo has no `packageManager` pin, I generated with the default (`allowBuilds`) key, matching actual local behavior. Recommend the org separately consider bumping the CI pnpm version pin to something >=10.16 so CI's install behavior matches local/dev; left untouched here since it's outside this recipe's scope.

## Verification

All three passed locally before opening this PR:
```
pnpm run policy:check          # "matches the policy"
pnpm install --frozen-lockfile # succeeds
pnpm run policy                # "Unchanged" — shasum of pnpm-workspace.yaml identical before/after
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEswUi4ANuB58rva48aHge